### PR TITLE
Add retry support for REMReM requests

### DIFF
--- a/eiffel-gerrit-plugin-script
+++ b/eiffel-gerrit-plugin-script
@@ -44,9 +44,9 @@ function do_rebuild {
 
   mvn clean install package -DskipTests
 
-  mv src/main/docker/env.bash target/env.bash
-  mv src/main/docker/docker-compose.yml target/docker-compose.yml
-  mv src/main/docker/Dockerfile target/Dockerfile
+  cp src/main/docker/env.bash target/env.bash
+  cp src/main/docker/docker-compose.yml target/docker-compose.yml
+  cp src/main/docker/Dockerfile target/Dockerfile
 
   JAR_LOCATION=$(ls target/ | grep '^eiffel-gerrit-plugin-[0-9]*.[0-9]*.[0-9]*.jar')
   docker build -f target/Dockerfile -t plugin-test target/ --build-arg JAR_LOCATION=./$JAR_LOCATION

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,13 @@
             <version>1.2.4.RELEASE</version>
         </dependency>
 
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <version>2.0</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Dependencies for testing -->
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,28 +68,15 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <version>5.2.0.RELEASE</version>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-all</artifactId>
+            <version>1.1.0</version>
         </dependency>
 
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-aspects</artifactId>
-            <version>5.2.0.RELEASE</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.retry</groupId>
-            <artifactId>spring-retry</artifactId>
-            <version>1.2.4.RELEASE</version>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-            <version>2.0</version>
-            <scope>provided</scope>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-retry</artifactId>
+            <version>1.1.0</version>
         </dependency>
 
         <!-- Dependencies for testing -->

--- a/pom.xml
+++ b/pom.xml
@@ -116,13 +116,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-            <version>5.2.0.RELEASE</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-reflect</artifactId>
             <version>2.0.4</version>

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,13 @@
             <version>5.2.0.RELEASE</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-reflect</artifactId>
+            <version>2.0.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
             <version>1.7.26</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
@@ -66,6 +67,24 @@
             <version>1.0.1</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>5.2.0.RELEASE</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aspects</artifactId>
+            <version>5.2.0.RELEASE</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+            <version>1.2.4.RELEASE</version>
+        </dependency>
+
         <!-- Dependencies for testing -->
         <dependency>
             <groupId>junit</groupId>
@@ -73,28 +92,39 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
             <version>2.0.2</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
             <version>2.0.2</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.13.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>5.2.0.RELEASE</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/configuration/RetryConfiguration.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/configuration/RetryConfiguration.java
@@ -1,0 +1,33 @@
+package com.ericsson.gerrit.plugins.eiffel.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+
+@Configuration
+@EnableRetry
+public class RetryConfiguration {
+
+    private static final long INITIAL_INTERVAL = 1000;
+    private static final int MULTIPLIER = 2;
+    private static final int MAX_ATTEMPTS = 5;
+
+    @Bean
+    public RetryTemplate retryTemplate() {
+        RetryTemplate retryTemplate = new RetryTemplate();
+
+        ExponentialBackOffPolicy exponentialBackOffPolicy = new ExponentialBackOffPolicy();
+        exponentialBackOffPolicy.setInitialInterval(INITIAL_INTERVAL);
+        exponentialBackOffPolicy.setMultiplier(MULTIPLIER);
+        retryTemplate.setBackOffPolicy(exponentialBackOffPolicy);
+
+        SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy();
+        retryPolicy.setMaxAttempts(MAX_ATTEMPTS);
+        retryTemplate.setRetryPolicy(retryPolicy);
+
+        return retryTemplate;
+    }
+}

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/configuration/RetryConfiguration.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/configuration/RetryConfiguration.java
@@ -1,6 +1,9 @@
 package com.ericsson.gerrit.plugins.eiffel.configuration;
 
-import org.springframework.context.annotation.Bean;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Default;
+import javax.enterprise.inject.Produces;
+
 import org.springframework.context.annotation.Configuration;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.retry.backoff.ExponentialBackOffPolicy;
@@ -9,13 +12,15 @@ import org.springframework.retry.support.RetryTemplate;
 
 @Configuration
 @EnableRetry
+@Dependent
 public class RetryConfiguration {
 
     private static final long INITIAL_INTERVAL = 1000;
     private static final int MULTIPLIER = 2;
     private static final int MAX_ATTEMPTS = 5;
 
-    @Bean
+    @Produces
+    @Default
     public RetryTemplate retryTemplate() {
         RetryTemplate retryTemplate = new RetryTemplate();
 

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/configuration/RetryConfiguration.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/configuration/RetryConfiguration.java
@@ -1,3 +1,20 @@
+/*
+   Copyright 2019 Ericsson AB.
+   For a full list of individual contributors, please see the commit history.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package com.ericsson.gerrit.plugins.eiffel.configuration;
 
 import io.github.resilience4j.retry.IntervalFunction;

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/exceptions/HttpRequestFailedException.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/exceptions/HttpRequestFailedException.java
@@ -10,4 +10,8 @@ public class HttpRequestFailedException extends RuntimeException {
     public HttpRequestFailedException(final String message) {
         super(message);
     }
+
+    public HttpRequestFailedException(final Throwable e) {
+        super(e);
+    }
 }

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/exceptions/HttpRequestFailedException.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/exceptions/HttpRequestFailedException.java
@@ -1,6 +1,6 @@
 package com.ericsson.gerrit.plugins.eiffel.exceptions;
 
-public class HttpRequestFailedException extends Exception {
+public class HttpRequestFailedException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
     public HttpRequestFailedException(final String message, final Throwable e) {

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/exceptions/MissingConfigurationException.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/exceptions/MissingConfigurationException.java
@@ -1,6 +1,6 @@
 package com.ericsson.gerrit.plugins.eiffel.exceptions;
 
-public class MissingConfigurationException extends Exception {
+public class MissingConfigurationException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
     public MissingConfigurationException(final String message, final Throwable e) {

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/listeners/AbstractEventListener.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/listeners/AbstractEventListener.java
@@ -17,9 +17,6 @@
 package com.ericsson.gerrit.plugins.eiffel.listeners;
 
 import java.io.File;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Supplier;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/listeners/AbstractEventListener.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/listeners/AbstractEventListener.java
@@ -98,11 +98,19 @@ public abstract class AbstractEventListener implements EventListener {
         return pluginConfig;
     }
 
+    /**
+     * Sends an Eiffel message to the REMReM service.
+     * RetryConfiguration contains the retry policy for the send method.
+     *
+     * @param eiffelEvent
+     * @param pluginConfig
+     */
     public void sendEiffelEvent(EiffelEvent eiffelEvent, EiffelPluginConfiguration pluginConfig) {
         EiffelEventSender eiffelEventSender = new EiffelEventSender(pluginConfig);
         eiffelEventSender.setEiffelEventType(eiffelEvent.getClass().getSimpleName());
         eiffelEventSender.setEiffelEventMessage(eiffelEvent);
 
+        // TODO Queue send calls as async jobs
         Retry policy = retryConfiguration.getRetryPolicy();
         Runnable decoratedRunnable = Decorators.ofRunnable(() -> eiffelEventSender.send())
                                                .withRetry(policy)

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/listeners/ChangeMergedEventListener.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/listeners/ChangeMergedEventListener.java
@@ -29,6 +29,7 @@ import org.springframework.retry.support.RetryTemplate;
 import com.ericsson.gerrit.plugins.eiffel.configuration.EiffelPluginConfiguration;
 import com.ericsson.gerrit.plugins.eiffel.events.EiffelSourceChangeSubmittedEvent;
 import com.ericsson.gerrit.plugins.eiffel.events.generators.EiffelSourceChangeSubmittedEventGenerator;
+import com.ericsson.gerrit.plugins.eiffel.exceptions.HttpRequestFailedException;
 import com.ericsson.gerrit.plugins.eiffel.messaging.EiffelEventSender;
 import com.google.gerrit.extensions.annotations.PluginData;
 import com.google.gerrit.extensions.annotations.PluginName;
@@ -71,7 +72,7 @@ public class ChangeMergedEventListener extends AbstractEventListener {
         EiffelEventSender eiffelEventSender = new EiffelEventSender(pluginConfig);
         eiffelEventSender.setEiffelEventType(eiffelEvent.getClass().getSimpleName());
         eiffelEventSender.setEiffelEventMessage(eiffelEvent);
-        retryTemplate.execute(new RetryCallback<Void, RuntimeException>() {
+        retryTemplate.execute(new RetryCallback<Void, HttpRequestFailedException>() {
             @Override
             public Void doWithRetry(RetryContext context) {
                 eiffelEventSender.send();

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/listeners/ChangeMergedEventListener.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/listeners/ChangeMergedEventListener.java
@@ -21,16 +21,10 @@ import java.io.File;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.retry.RetryCallback;
-import org.springframework.retry.RetryContext;
-import org.springframework.retry.support.RetryTemplate;
 
 import com.ericsson.gerrit.plugins.eiffel.configuration.EiffelPluginConfiguration;
 import com.ericsson.gerrit.plugins.eiffel.events.EiffelSourceChangeSubmittedEvent;
 import com.ericsson.gerrit.plugins.eiffel.events.generators.EiffelSourceChangeSubmittedEventGenerator;
-import com.ericsson.gerrit.plugins.eiffel.exceptions.HttpRequestFailedException;
-import com.ericsson.gerrit.plugins.eiffel.messaging.EiffelEventSender;
 import com.google.gerrit.extensions.annotations.PluginData;
 import com.google.gerrit.extensions.annotations.PluginName;
 import com.google.gerrit.server.events.ChangeMergedEvent;
@@ -45,9 +39,6 @@ import com.google.inject.Inject;
 public class ChangeMergedEventListener extends AbstractEventListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ChangeMergedEventListener.class);
-
-    @Autowired
-    private RetryTemplate retryTemplate;
 
     @Inject
     public ChangeMergedEventListener(@PluginName final String pluginName,
@@ -69,15 +60,6 @@ public class ChangeMergedEventListener extends AbstractEventListener {
                 changeMergedEvent);
         EiffelSourceChangeSubmittedEvent eiffelEvent = EiffelSourceChangeSubmittedEventGenerator.generate(
                 changeMergedEvent, pluginConfig);
-        EiffelEventSender eiffelEventSender = new EiffelEventSender(pluginConfig);
-        eiffelEventSender.setEiffelEventType(eiffelEvent.getClass().getSimpleName());
-        eiffelEventSender.setEiffelEventMessage(eiffelEvent);
-        retryTemplate.execute(new RetryCallback<Void, HttpRequestFailedException>() {
-            @Override
-            public Void doWithRetry(RetryContext context) {
-                eiffelEventSender.send();
-                return null;
-            }
-        });
+        sendEiffelEvent(eiffelEvent, pluginConfig);
     }
 }

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/listeners/PatchsetCreatedEventListener.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/listeners/PatchsetCreatedEventListener.java
@@ -29,6 +29,7 @@ import org.springframework.retry.support.RetryTemplate;
 import com.ericsson.gerrit.plugins.eiffel.configuration.EiffelPluginConfiguration;
 import com.ericsson.gerrit.plugins.eiffel.events.EiffelSourceChangeCreatedEvent;
 import com.ericsson.gerrit.plugins.eiffel.events.generators.EiffelSourceChangeCreatedEventGenerator;
+import com.ericsson.gerrit.plugins.eiffel.exceptions.HttpRequestFailedException;
 import com.ericsson.gerrit.plugins.eiffel.messaging.EiffelEventSender;
 import com.google.gerrit.extensions.annotations.PluginData;
 import com.google.gerrit.extensions.annotations.PluginName;
@@ -73,7 +74,7 @@ public class PatchsetCreatedEventListener extends AbstractEventListener {
         EiffelEventSender eiffelEventSender = new EiffelEventSender(pluginConfig);
         eiffelEventSender.setEiffelEventType(eiffelEvent.getClass().getSimpleName());
         eiffelEventSender.setEiffelEventMessage(eiffelEvent);
-        retryTemplate.execute(new RetryCallback<Void, RuntimeException>() {
+        retryTemplate.execute(new RetryCallback<Void, HttpRequestFailedException>() {
             @Override
             public Void doWithRetry(RetryContext context) {
                 eiffelEventSender.send();

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/listeners/PatchsetCreatedEventListener.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/listeners/PatchsetCreatedEventListener.java
@@ -21,7 +21,6 @@ import java.io.File;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
 import org.springframework.retry.support.RetryTemplate;
@@ -47,7 +46,7 @@ public class PatchsetCreatedEventListener extends AbstractEventListener {
     private static final Logger LOGGER = LoggerFactory.getLogger(
             PatchsetCreatedEventListener.class);
     
-    @Autowired
+    @Inject
     private RetryTemplate retryTemplate;
 
     @Inject

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/messaging/EiffelEventSender.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/messaging/EiffelEventSender.java
@@ -72,7 +72,7 @@ public class EiffelEventSender {
             LOGGER.error("Failed to send eiffel message.", e1);
         } catch (HttpRequestFailedException e2) {
             LOGGER.error("Failed to send eiffel message.", e2);
-            throw new RuntimeException(e2);
+            throw e2;
         }
     }
 

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/messaging/EiffelEventSender.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/messaging/EiffelEventSender.java
@@ -61,7 +61,7 @@ public class EiffelEventSender {
 
     /**
      * Sends a REMReM Eiffel message to the generateAndPublish endpoint. RuntimeException is thrown
-     * when a HttpRequestFailedException occurs so that the retry logic works.
+     * when an IOException or HttpRequestFailedException occurs so that the retry logic works.
      *
      */
     public void send() {

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/messaging/EiffelEventSender.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/messaging/EiffelEventSender.java
@@ -72,7 +72,7 @@ public class EiffelEventSender {
             LOGGER.error("Failed to send eiffel message.", e);
         } catch (IOException e) {
             LOGGER.error("Failed to send eiffel message.", e);
-            throw new RuntimeException(e);
+            throw new HttpRequestFailedException(e);
         } catch (HttpRequestFailedException e) {
             LOGGER.error("Failed to send eiffel message.", e);
             throw e;

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/messaging/EiffelEventSender.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/messaging/EiffelEventSender.java
@@ -60,16 +60,19 @@ public class EiffelEventSender {
     }
 
     /**
-     * Sends a REMReM eiffel message using
+     * Sends a REMReM Eiffel message to the generateAndPublish endpoint. RuntimeException is thrown
+     * when a HttpRequestFailedException occurs so that the retry logic works.
      *
      */
     public void send() {
         try {
             verifyConfiguration();
             generateAndPublish();
-        } catch (URISyntaxException | IOException | MissingConfigurationException
-                | HttpRequestFailedException e) {
-            LOGGER.error("Failed to send eiffel message.", e);
+        } catch (URISyntaxException | IOException | MissingConfigurationException e1) {
+            LOGGER.error("Failed to send eiffel message.", e1);
+        } catch (HttpRequestFailedException e2) {
+            LOGGER.error("Failed to send eiffel message.", e2);
+            throw new RuntimeException(e2);
         }
     }
 

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/messaging/EiffelEventSender.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/messaging/EiffelEventSender.java
@@ -103,7 +103,7 @@ public class EiffelEventSender {
 
         if (HttpStatus.SC_OK == statusCode) {
             LOGGER.info("Generated and published eiffel message successfully. \n{}", result);
-        } else if (HttpStatus.SC_BAD_GATEWAY == statusCode || HttpStatus.SC_SERVICE_UNAVAILABLE == statusCode ) {
+        } else if (HttpStatus.SC_INTERNAL_SERVER_ERROR == statusCode || HttpStatus.SC_SERVICE_UNAVAILABLE == statusCode ) {
             final String errorMessage = String.format(
                     "Could not generate and publish eiffel message due to server issue or invalid json data, "
                             + "Status Code :: %d\npublishURL :: %s\ninput message :: %s\nError Message  :: %s",

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/messaging/EiffelEventSender.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/messaging/EiffelEventSender.java
@@ -68,11 +68,14 @@ public class EiffelEventSender {
         try {
             verifyConfiguration();
             generateAndPublish();
-        } catch (URISyntaxException | IOException | MissingConfigurationException e1) {
-            LOGGER.error("Failed to send eiffel message.", e1);
-        } catch (HttpRequestFailedException e2) {
-            LOGGER.error("Failed to send eiffel message.", e2);
-            throw e2;
+        } catch (URISyntaxException | MissingConfigurationException e) {
+            LOGGER.error("Failed to send eiffel message.", e);
+        } catch (IOException e) {
+            LOGGER.error("Failed to send eiffel message.", e);
+            throw new RuntimeException(e);
+        } catch (HttpRequestFailedException e) {
+            LOGGER.error("Failed to send eiffel message.", e);
+            throw e;
         }
     }
 
@@ -100,7 +103,7 @@ public class EiffelEventSender {
 
         if (HttpStatus.SC_OK == statusCode) {
             LOGGER.info("Generated and published eiffel message successfully. \n{}", result);
-        } else {
+        } else if (HttpStatus.SC_BAD_GATEWAY == statusCode || HttpStatus.SC_SERVICE_UNAVAILABLE == statusCode ) {
             final String errorMessage = String.format(
                     "Could not generate and publish eiffel message due to server issue or invalid json data, "
                             + "Status Code :: %d\npublishURL :: %s\ninput message :: %s\nError Message  :: %s",

--- a/src/test/java/com/ericsson/gerrit/plugins/eiffel/messaging/EiffelEventSenderTest.java
+++ b/src/test/java/com/ericsson/gerrit/plugins/eiffel/messaging/EiffelEventSenderTest.java
@@ -26,7 +26,7 @@ public class EiffelEventSenderTest {
 
     private static final String EIFFEL_TYPE = "EiffelSourceChangeCreatedEvent";
     private static final int STATUS_OK = HttpStatus.SC_OK;
-    private static final int STATUS_NOT_FOUND = HttpStatus.SC_NOT_FOUND;
+    private static final int STATUS_NOT_FOUND = HttpStatus.SC_INTERNAL_SERVER_ERROR;
 
     @Before
     public void beforeTest() throws IOException, URISyntaxException {

--- a/src/test/java/com/ericsson/gerrit/plugins/eiffel/messaging/RetryRequestTest.java
+++ b/src/test/java/com/ericsson/gerrit/plugins/eiffel/messaging/RetryRequestTest.java
@@ -2,6 +2,7 @@ package com.ericsson.gerrit.plugins.eiffel.messaging;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
@@ -11,6 +12,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
@@ -23,17 +29,29 @@ import com.ericsson.eiffelcommons.utils.ResponseEntity;
 import com.ericsson.gerrit.plugins.eiffel.configuration.EiffelPluginConfiguration;
 import com.ericsson.gerrit.plugins.eiffel.configuration.RetryConfiguration;
 import com.ericsson.gerrit.plugins.eiffel.events.EiffelSourceChangeCreatedEvent;
+import com.ericsson.gerrit.plugins.eiffel.events.EiffelSourceChangeSubmittedEvent;
+import com.ericsson.gerrit.plugins.eiffel.events.generators.EiffelSourceChangeSubmittedEventGenerator;
+import com.ericsson.gerrit.plugins.eiffel.exceptions.HttpRequestFailedException;
+import com.ericsson.gerrit.plugins.eiffel.listeners.ChangeMergedEventListener;
+import com.google.gerrit.server.events.ChangeMergedEvent;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = RetryConfiguration.class)
+@PrepareForTest({ EiffelSourceChangeSubmittedEventGenerator.class,
+        ChangeMergedEventListener.class })
 public class RetryRequestTest {
     private EiffelPluginConfiguration pluginConfig;
     private HttpRequest httpRequest;
     private ResponseEntity response;
+    private ChangeMergedEvent changeMergedEvent;
     private MutableInt counter = new MutableInt();
+    private EiffelSourceChangeSubmittedEvent eiffelEvent = new EiffelSourceChangeSubmittedEvent();
 
     private static final String EIFFEL_TYPE = "EiffelSourceChangeCreatedEvent";
     private static final int STATUS_ERROR = HttpStatus.SC_INTERNAL_SERVER_ERROR;
+    private static final String PLUGIN_NAME = "Eiffel-Integration";
+    private static final File FILE_DIR = new File("");
 
     @Autowired
     private RetryTemplate retryTemplate;
@@ -49,28 +67,40 @@ public class RetryRequestTest {
         counter.setValue(0);
 
         EiffelEventSender sender = new EiffelEventSender(pluginConfig, httpRequest);
-        retryTemplate.execute(new RetryCallback<Void, RuntimeException>() {
+        sender.setEiffelEventMessage(new EiffelSourceChangeCreatedEvent());
+        sender.setEiffelEventType(EIFFEL_TYPE);
+        retryTemplate.execute(new RetryCallback<Void, HttpRequestFailedException>() {
             @Override
             public Void doWithRetry(RetryContext context) {
                 counter.setValue(counter.getValue().intValue() + 1);
-                sender.setEiffelEventMessage(new EiffelSourceChangeCreatedEvent());
-                sender.setEiffelEventType(EIFFEL_TYPE);
                 sender.send();
                 return null;
             }
         });
 
-        int expectedValue = 5;
+        int expectedValue = Whitebox.getInternalState(retryTemplate, "MAX_ATTEMPTS");
         int actualValue = counter.getValue().intValue();
         String errorMessage = String.format("Expected retry counter to be %d but was %d",
                 expectedValue, actualValue);
         assertEquals(errorMessage, expectedValue, actualValue);
     }
 
+    @Test(expected = RuntimeException.class)
+    public void testPrepareAndSendEiffelEvent() throws Exception {
+        setUpMockActions();
+        setUpMocksAndActionsForMethodInvoke();
+
+        ChangeMergedEventListener listener = new ChangeMergedEventListener(PLUGIN_NAME, FILE_DIR);
+        Whitebox.setInternalState(listener, "retryTemplate", retryTemplate);
+        Whitebox.invokeMethod(listener, "prepareAndSendEiffelEvent", changeMergedEvent,
+                pluginConfig);
+    }
+
     private void setUpMockObjects() throws URISyntaxException, IOException {
         httpRequest = Mockito.mock(HttpRequest.class);
         pluginConfig = Mockito.mock(EiffelPluginConfiguration.class);
         response = Mockito.mock(ResponseEntity.class);
+        changeMergedEvent = Mockito.mock(ChangeMergedEvent.class);
     }
 
     private void setUpMockActions() throws URISyntaxException, IOException {
@@ -80,5 +110,16 @@ public class RetryRequestTest {
         Mockito.when(pluginConfig.getRemremPublishURL()).thenReturn("");
         Mockito.when(pluginConfig.getRemremUsername()).thenReturn("");
         Mockito.when(pluginConfig.getRemremPassword()).thenReturn("");
+    }
+
+    private void setUpMocksAndActionsForMethodInvoke() throws Exception {
+        PowerMockito.mockStatic(EiffelSourceChangeSubmittedEventGenerator.class);
+        Mockito.when(
+                EiffelSourceChangeSubmittedEventGenerator.generate(changeMergedEvent, pluginConfig))
+               .thenReturn(eiffelEvent);
+        EiffelEventSender sender = new EiffelEventSender(pluginConfig, httpRequest);
+        PowerMockito.whenNew(EiffelEventSender.class)
+                    .withArguments(pluginConfig)
+                    .thenReturn(sender);
     }
 }

--- a/src/test/java/com/ericsson/gerrit/plugins/eiffel/messaging/RetryRequestTest.java
+++ b/src/test/java/com/ericsson/gerrit/plugins/eiffel/messaging/RetryRequestTest.java
@@ -1,0 +1,84 @@
+package com.ericsson.gerrit.plugins.eiffel.messaging;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.apache.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.ericsson.eiffelcommons.utils.HttpRequest;
+import com.ericsson.eiffelcommons.utils.ResponseEntity;
+import com.ericsson.gerrit.plugins.eiffel.configuration.EiffelPluginConfiguration;
+import com.ericsson.gerrit.plugins.eiffel.configuration.RetryConfiguration;
+import com.ericsson.gerrit.plugins.eiffel.events.EiffelSourceChangeCreatedEvent;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = RetryConfiguration.class)
+public class RetryRequestTest {
+    private EiffelPluginConfiguration pluginConfig;
+    private HttpRequest httpRequest;
+    private ResponseEntity response;
+    private MutableInt counter = new MutableInt();
+
+    private static final String EIFFEL_TYPE = "EiffelSourceChangeCreatedEvent";
+    private static final int STATUS_ERROR = HttpStatus.SC_INTERNAL_SERVER_ERROR;
+
+    @Autowired
+    private RetryTemplate retryTemplate;
+
+    @Before
+    public void beforeTest() throws IOException, URISyntaxException {
+        setUpMockObjects();
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testRetryLogic() throws URISyntaxException, IOException {
+        setUpMockActions();
+        counter.setValue(0);
+
+        EiffelEventSender sender = new EiffelEventSender(pluginConfig, httpRequest);
+        retryTemplate.execute(new RetryCallback<Void, RuntimeException>() {
+            @Override
+            public Void doWithRetry(RetryContext context) {
+                counter.setValue(counter.getValue().intValue() + 1);
+                sender.setEiffelEventMessage(new EiffelSourceChangeCreatedEvent());
+                sender.setEiffelEventType(EIFFEL_TYPE);
+                sender.send();
+                return null;
+            }
+        });
+
+        int expectedValue = 5;
+        int actualValue = counter.getValue().intValue();
+        String errorMessage = String.format("Expected retry counter to be %d but was %d",
+                expectedValue, actualValue);
+        assertEquals(errorMessage, expectedValue, actualValue);
+    }
+
+    private void setUpMockObjects() throws URISyntaxException, IOException {
+        httpRequest = Mockito.mock(HttpRequest.class);
+        pluginConfig = Mockito.mock(EiffelPluginConfiguration.class);
+        response = Mockito.mock(ResponseEntity.class);
+    }
+
+    private void setUpMockActions() throws URISyntaxException, IOException {
+        Mockito.when(httpRequest.performRequest()).thenReturn(response);
+        Mockito.when(response.getStatusCode()).thenReturn(STATUS_ERROR);
+        Mockito.when(response.getBody()).thenReturn("");
+        Mockito.when(pluginConfig.getRemremPublishURL()).thenReturn("");
+        Mockito.when(pluginConfig.getRemremUsername()).thenReturn("");
+        Mockito.when(pluginConfig.getRemremPassword()).thenReturn("");
+    }
+}

--- a/src/test/java/com/ericsson/gerrit/plugins/eiffel/messaging/RetryRequestTest.java
+++ b/src/test/java/com/ericsson/gerrit/plugins/eiffel/messaging/RetryRequestTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.function.Function;
 
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.http.HttpStatus;
@@ -14,15 +15,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.retry.RetryCallback;
-import org.springframework.retry.RetryContext;
-import org.springframework.retry.support.RetryTemplate;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.ericsson.eiffelcommons.utils.HttpRequest;
 import com.ericsson.eiffelcommons.utils.ResponseEntity;
@@ -31,13 +25,12 @@ import com.ericsson.gerrit.plugins.eiffel.configuration.RetryConfiguration;
 import com.ericsson.gerrit.plugins.eiffel.events.EiffelSourceChangeCreatedEvent;
 import com.ericsson.gerrit.plugins.eiffel.events.EiffelSourceChangeSubmittedEvent;
 import com.ericsson.gerrit.plugins.eiffel.events.generators.EiffelSourceChangeSubmittedEventGenerator;
-import com.ericsson.gerrit.plugins.eiffel.exceptions.HttpRequestFailedException;
 import com.ericsson.gerrit.plugins.eiffel.listeners.ChangeMergedEventListener;
 import com.google.gerrit.server.events.ChangeMergedEvent;
 
+import io.github.resilience4j.retry.Retry;
+
 @RunWith(PowerMockRunner.class)
-@PowerMockRunnerDelegate(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = RetryConfiguration.class)
 @PrepareForTest({ EiffelSourceChangeSubmittedEventGenerator.class,
         ChangeMergedEventListener.class })
 public class RetryRequestTest {
@@ -53,45 +46,47 @@ public class RetryRequestTest {
     private static final String PLUGIN_NAME = "Eiffel-Integration";
     private static final File FILE_DIR = new File("");
 
-    @Autowired
-    private RetryTemplate retryTemplate;
-
     @Before
     public void beforeTest() throws IOException, URISyntaxException {
         setUpMockObjects();
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testRetryLogic() throws URISyntaxException, IOException {
         setUpMockActions();
         counter.setValue(0);
 
-        EiffelEventSender sender = new EiffelEventSender(pluginConfig, httpRequest);
-        sender.setEiffelEventMessage(new EiffelSourceChangeCreatedEvent());
-        sender.setEiffelEventType(EIFFEL_TYPE);
-        retryTemplate.execute(new RetryCallback<Void, HttpRequestFailedException>() {
-            @Override
-            public Void doWithRetry(RetryContext context) {
-                counter.setValue(counter.getValue().intValue() + 1);
-                sender.send();
-                return null;
-            }
-        });
+        RetryConfiguration retryConfiguration = new RetryConfiguration();
+        EiffelEventSender eiffelEventSender = new EiffelEventSender(pluginConfig, httpRequest);
+        eiffelEventSender.setEiffelEventMessage(new EiffelSourceChangeCreatedEvent());
+        eiffelEventSender.setEiffelEventType(EIFFEL_TYPE);
 
-        int expectedValue = Whitebox.getInternalState(retryTemplate, "MAX_ATTEMPTS");
-        int actualValue = counter.getValue().intValue();
-        String errorMessage = String.format("Expected retry counter to be %d but was %d",
-                expectedValue, actualValue);
-        assertEquals(errorMessage, expectedValue, actualValue);
+        Retry policy = retryConfiguration.getRetryPolicy();
+        Function<Integer, Void> methodToTry = Retry.decorateFunction(
+                policy, (Integer dummy) -> {
+                    counter.setValue(counter.getValue().intValue() + 1);
+                    eiffelEventSender.send();
+                    return null;
+                });
+        try {
+            methodToTry.apply(1);
+        } catch (Exception e) {
+            int expectedValue = retryConfiguration.getMaxAttempts();
+            int actualValue = counter.getValue().intValue();
+            String errorMessage = String.format("Expected retry counter to be %d but was %d",
+                    expectedValue, actualValue);
+            assertEquals(errorMessage, expectedValue, actualValue);
+        }
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testPrepareAndSendEiffelEvent() throws Exception {
         setUpMockActions();
         setUpMocksAndActionsForMethodInvoke();
 
+        RetryConfiguration retryConfiguration = new RetryConfiguration();
         ChangeMergedEventListener listener = new ChangeMergedEventListener(PLUGIN_NAME, FILE_DIR);
-        Whitebox.setInternalState(listener, "retryTemplate", retryTemplate);
+        Whitebox.setInternalState(listener, "retryConfiguration", retryConfiguration);
         Whitebox.invokeMethod(listener, "prepareAndSendEiffelEvent", changeMergedEvent,
                 pluginConfig);
     }

--- a/src/test/java/com/ericsson/gerrit/plugins/eiffel/messaging/RetryRequestTest.java
+++ b/src/test/java/com/ericsson/gerrit/plugins/eiffel/messaging/RetryRequestTest.java
@@ -79,7 +79,7 @@ public class RetryRequestTest {
         }
     }
 
-    @Test
+    @Test(expected = Test.None.class)
     public void testPrepareAndSendEiffelEvent() throws Exception {
         setUpMockActions();
         setUpMocksAndActionsForMethodInvoke();


### PR DESCRIPTION
### Applicable Issues
Closes https://github.com/eiffel-community/eiffel-gerrit-plugin/issues/31

### Description of the Change
This solution uses Spring-retry to send multiple request attempts to REMReM.
A retry configuration class contains the RetryTemplate bean with the settings for the retry mechanism.
This RetryTemplate is then used to wrap the send method and catches the RuntimeExceptions thrown by the sender when a http request fails.
The RuntimeException is what triggers the retry.

TODO: circuit breaker pattern needs to be investigated and other questions that might arise.

### Alternate Designs

### Benefits

### Possible Drawbacks

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: @Christoffer-Cortes 
