### PR TITLE
Docs: Correct name of Gerrit repositories' configuration file

### DIFF
--- a/src/main/resources/Documentation/about.md
+++ b/src/main/resources/Documentation/about.md
@@ -78,12 +78,12 @@ Configuration
 -------------
 
 Plugin configuration stored as part of the project configuration and can be edited/configured in two ways - by editing
-project.conf file:
+project.config file:
 
     cd <your repository>
     git fetch origin refs/meta/config:refs/remotes/origin/meta/config
     git checkout meta/config
-    <open project.conf and plugin configuration as it shown in example above>
+    <open project.config and plugin configuration as it shown in example above>
     git commit -a
     git push origin meta/config:meta/config
 


### PR DESCRIPTION
### Applicable Issues
N/A; issues for typo corrections are unreasonable.

### Description of the Change
Previously the documentation claimed that the main configuration file on refs/meta/config of a Gerrit repository is project.conf, but it's project.config.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
