### PR TITLE
Send calls are now threaded

### DIFF
--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/listeners/AbstractEventListener.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/listeners/AbstractEventListener.java
@@ -84,7 +84,8 @@ public abstract class AbstractEventListener implements EventListener {
 
     private void initializeThreadPoolExecutor() {
         if (initialized.compareAndSet(false, true)) {
-            executor = new ThreadPoolExecutor(CORE_POOL_SIZE, MAXIMUM_POOL_SIZE, KEEP_ALIVE, TIME_UNIT, queue);
+            executor = new ThreadPoolExecutor(CORE_POOL_SIZE, MAXIMUM_POOL_SIZE, KEEP_ALIVE,
+                    TIME_UNIT, queue);
         }
     }
 

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/listeners/AbstractEventListener.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/listeners/AbstractEventListener.java
@@ -82,13 +82,6 @@ public abstract class AbstractEventListener implements EventListener {
         initializeThreadPoolExecutor();
     }
 
-    private void initializeThreadPoolExecutor() {
-        if (initialized.compareAndSet(false, true)) {
-            executor = new ThreadPoolExecutor(CORE_POOL_SIZE, MAXIMUM_POOL_SIZE, KEEP_ALIVE,
-                    TIME_UNIT, queue);
-        }
-    }
-
     @Override
     public void onEvent(final Event gerritEvent) {
         if (!isExpectedGerritEvent(gerritEvent)) {
@@ -170,6 +163,13 @@ public abstract class AbstractEventListener implements EventListener {
 
     protected abstract void prepareAndSendEiffelEvent(Event gerritEvent,
             EiffelPluginConfiguration pluginConfig);
+
+    private void initializeThreadPoolExecutor() {
+        if (initialized.compareAndSet(false, true)) {
+            executor = new ThreadPoolExecutor(CORE_POOL_SIZE, MAXIMUM_POOL_SIZE, KEEP_ALIVE,
+                    TIME_UNIT, queue);
+        }
+    }
 
     private boolean isPluginEnabled(final EiffelPluginConfiguration pluginConfig,
             final String project) {


### PR DESCRIPTION
### Applicable Issues
Closes https://github.com/eiffel-community/eiffel-gerrit-plugin/issues/36

### Description of the Change
Added a ThreadPoolExecutor that takes care of send calls.

### Alternate Designs
There are other alternative implementations in for example the rabbitmq plugin for gerrit and in some internal code.

### Benefits
EventListener threads are no longer held.

### Possible Drawbacks
The queue is set to have 3 workers at the moment and a queue of an arbitrary length. I guess this could lead to our plugin taking up more memory.

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: @Christoffer-Cortes 
