### PR TITLE
Use plugin config

### DIFF
--- a/src/functionaltests/java/com/ericsson/gerrit/plugins/eiffel/linking/LinkingSteps.java
+++ b/src/functionaltests/java/com/ericsson/gerrit/plugins/eiffel/linking/LinkingSteps.java
@@ -212,7 +212,7 @@ public class LinkingSteps {
         patchSetCreatedEvent.patchSet = patchSetAttributeSupplier;
         patchSetCreatedEvent.changeKey = changeKey;
 
-        when(patchSetCreatedEvent.getProjectNameKey()).thenReturn(mock(NameKey.class));
+        when(patchSetCreatedEvent.getProjectNameKey()).thenReturn(new NameKey(PROJECT_NAME));
         return patchSetCreatedEvent;
     }
 
@@ -228,7 +228,7 @@ public class LinkingSteps {
         changeMergedEvent.changeKey = changeKey;
         changeMergedEvent.newRev = commitId;
 
-        when(changeMergedEvent.getProjectNameKey()).thenReturn(mock(NameKey.class));
+        when(changeMergedEvent.getProjectNameKey()).thenReturn(new NameKey(PROJECT_NAME));
         return changeMergedEvent;
     }
 

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/configuration/EiffelPluginConfiguration.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/configuration/EiffelPluginConfiguration.java
@@ -53,19 +53,21 @@ public class EiffelPluginConfiguration {
     private final boolean enabled;
     private final String flowContext;
     private File pluginDirectoryPath;
+    private final NameKey project;
 
     public EiffelPluginConfiguration(final String pluginName, final NameKey project,
             final PluginConfigFactory pluginConfigFactory) {
 
+        this.project = project;
         PluginConfig pluginConfig;
 
         try {
             pluginConfig = pluginConfigFactory.getFromProjectConfig(project, pluginName);
-        } catch (NoSuchProjectException e) {
+        } catch (final NoSuchProjectException e) {
             LOGGER.error("Could not initiate, error: {} \n{}", e.getMessage(), e);
             throw new ExceptionInInitializerError(
                     String.format("Can't read %s plugin configuration for project %s: %s",
-                            pluginName, project.toString(), e.getMessage()));
+                            pluginName, getProject(), e.getMessage()));
         }
         // Read plugin configuration
         this.enabled = pluginConfig.getBoolean(ENABLED, false);
@@ -90,7 +92,7 @@ public class EiffelPluginConfiguration {
                     String.format(
                             "Can't read %s plugin configuration for project %s: REMReM Generate URL is null",
                             pluginName,
-                            project.toString()));
+                            getProject()));
         }
         LOGGER.info("Loaded plugin configuration: {}", pluginConfig.toString());
     }
@@ -133,13 +135,22 @@ public class EiffelPluginConfiguration {
      *
      * @param pluginDirectoryPath
      */
-    public void setPluginDirectoryPath(File pluginDirectoryPath) {
+    public void setPluginDirectoryPath(final File pluginDirectoryPath) {
         this.pluginDirectoryPath = pluginDirectoryPath;
+    }
+
+
+    /**
+     * Retrieves the name of the project
+     * @return project name
+     */
+    public String getProject() {
+        return project.get();
     }
 
     /**
      * This method reads multiple values set manually by editing the project configuration
-     * and then setting it in the GUI so that the person who is having the privileges to the UI is aware of the 
+     * and then setting it in the GUI so that the person who is having the privileges to the UI is aware of the
      * parameters set manually.
      * Ex:
      * [eiffel-integration]
@@ -151,7 +162,7 @@ public class EiffelPluginConfiguration {
      */
     private String getMultiValueParameters(final String property, final PluginConfig pluginConfig) {
         String propertyValue = "";
-        String[] propertyValues = pluginConfig.getStringList(property);
+        final String[] propertyValues = pluginConfig.getStringList(property);
         if (propertyValues != null && propertyValues.length > 0) {
             propertyValue = Arrays.stream(propertyValues).collect(Collectors.joining(","));
             pluginConfig.setString(property, propertyValue);

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/events/generators/EiffelEventGenerator.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/events/generators/EiffelEventGenerator.java
@@ -16,7 +16,6 @@
 */
 package com.ericsson.gerrit.plugins.eiffel.events.generators;
 
-import java.io.File;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -27,6 +26,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.ericsson.gerrit.plugins.eiffel.configuration.EiffelPluginConfiguration;
 import com.ericsson.gerrit.plugins.eiffel.events.models.Link;
 import com.ericsson.gerrit.plugins.eiffel.exceptions.NoSuchElementException;
 import com.ericsson.gerrit.plugins.eiffel.storage.EventStorage;
@@ -67,12 +67,13 @@ public class EiffelEventGenerator {
     /**
      * Will for a given list of search criteria return the first found event
      */
-    protected static String getPreviousEiffelEventId(final String linkedEiffelEventType,
-            final String projectName,
-            final List<String> searchCriterias, final File pluginDirectoryPath) {
+    protected static String getPreviousEiffelEventId(final EiffelPluginConfiguration pluginConfig,
+            final String linkedEiffelEventType,
+            final List<String> searchCriterias) {
         for (final String searchCriteria : searchCriterias) {
-            final String eiffelEventId = getPreviousEiffelEventId(linkedEiffelEventType, projectName,
-                    searchCriteria, pluginDirectoryPath);
+            final String eiffelEventId = getPreviousEiffelEventId(pluginConfig,
+                    linkedEiffelEventType,
+                    searchCriteria);
             if (!StringUtils.isEmpty(eiffelEventId)) {
                 return eiffelEventId;
             }
@@ -80,13 +81,13 @@ public class EiffelEventGenerator {
         return "";
     }
 
-    protected static String getPreviousEiffelEventId(final String linkedEiffelEventType,
-            final String projectName,
-            final String searchCriteria, final File pluginDirectoryPath) {
+    protected static String getPreviousEiffelEventId(final EiffelPluginConfiguration pluginConfig,
+            final String linkedEiffelEventType,
+            final String searchCriteria ) {
         try {
-            final EventStorage eventStorage = EventStorageFactory.getEventStorage(pluginDirectoryPath,
+            final EventStorage eventStorage = EventStorageFactory.getEventStorage(pluginConfig,
                     linkedEiffelEventType);
-            final String lastEiffelEventId = getEiffelEventIdFromStorage(eventStorage, projectName,
+            final String lastEiffelEventId = getEiffelEventIdFromStorage(eventStorage, pluginConfig.getProject(),
                     searchCriteria);
             return lastEiffelEventId;
         } catch (final IllegalArgumentException e) {

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/events/generators/EiffelSourceChangeCreatedEventGenerator.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/events/generators/EiffelSourceChangeCreatedEventGenerator.java
@@ -16,9 +16,9 @@
 */
 package com.ericsson.gerrit.plugins.eiffel.events.generators;
 
-import java.io.File;
 import java.util.List;
 
+import com.ericsson.gerrit.plugins.eiffel.configuration.EiffelPluginConfiguration;
 import com.ericsson.gerrit.plugins.eiffel.events.EiffelSourceChangeCreatedEvent;
 import com.ericsson.gerrit.plugins.eiffel.events.EventType;
 import com.ericsson.gerrit.plugins.eiffel.events.models.Link;
@@ -43,8 +43,9 @@ public final class EiffelSourceChangeCreatedEventGenerator extends EiffelEventGe
      * @param commitInformation
      * @return EiffelSourceChangeCreatedEvent
      */
-    public static EiffelSourceChangeCreatedEvent generate(PatchSetCreatedEvent patchSetCreatedEvent,
-            File pluginDirectoryPath, CommitInformation commitInformation) {
+    public static EiffelSourceChangeCreatedEvent generate(final EiffelPluginConfiguration pluginConfig,
+            final PatchSetCreatedEvent patchSetCreatedEvent,
+            final CommitInformation commitInformation) {
         final ChangeAttribute changeAttribute = patchSetCreatedEvent.change.get();
         final PatchSetAttribute patchSetAttribute = patchSetCreatedEvent.patchSet.get();
         final String projectName = changeAttribute.project;
@@ -58,7 +59,7 @@ public final class EiffelSourceChangeCreatedEventGenerator extends EiffelEventGe
         final int deletions = patchSetAttribute.sizeDeletions;
         final String changeId = patchSetCreatedEvent.changeKey.toString();
 
-        EiffelSourceChangeCreatedEvent eiffelEvent = new EiffelSourceChangeCreatedEvent();
+        final EiffelSourceChangeCreatedEvent eiffelEvent = new EiffelSourceChangeCreatedEvent();
         eiffelEvent.msgParams.meta.type = TYPE;
         eiffelEvent.msgParams.meta.source.name = META_SOURCE_NAME;
         eiffelEvent.msgParams.meta.source.host = determineHostName();
@@ -79,17 +80,17 @@ public final class EiffelSourceChangeCreatedEventGenerator extends EiffelEventGe
         eiffelEvent.eventParams.data.gitIdentifier.branch = branch;
         eiffelEvent.eventParams.data.gitIdentifier.repoName = projectName;
 
-        String previousSourceChangeCreatedEvent = getPreviousEiffelEventId(EventType.SCC_EVENT,
-                projectName, changeId, pluginDirectoryPath);
+        final String previousSourceChangeCreatedEvent = getPreviousEiffelEventId(pluginConfig,
+                EventType.SCC_EVENT, changeId);
         final Link previousVersionLink = createLink(LINK_TYPE_PREVIOUS_VERSION,
                 previousSourceChangeCreatedEvent);
         if (previousVersionLink != null) {
             eiffelEvent.eventParams.links.add(previousVersionLink);
         }
 
-        List<String> parentsSHAs = commitInformation.getParentsSHAs(commitId, projectName);
-        String previousSourceChangeSubmittedEventId = getPreviousEiffelEventId(EventType.SCS_EVENT,
-                projectName, parentsSHAs, pluginDirectoryPath);
+        final List<String> parentsSHAs = commitInformation.getParentsSHAs(commitId, projectName);
+        final String previousSourceChangeSubmittedEventId = getPreviousEiffelEventId(pluginConfig,
+                EventType.SCS_EVENT, parentsSHAs);
         final Link baseLink = createLink(LINK_TYPE_BASE, previousSourceChangeSubmittedEventId);
         if (baseLink != null) {
             eiffelEvent.eventParams.links.add(baseLink);

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/events/generators/EiffelSourceChangeSubmittedEventGenerator.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/events/generators/EiffelSourceChangeSubmittedEventGenerator.java
@@ -16,9 +16,9 @@
 */
 package com.ericsson.gerrit.plugins.eiffel.events.generators;
 
-import java.io.File;
 import java.util.List;
 
+import com.ericsson.gerrit.plugins.eiffel.configuration.EiffelPluginConfiguration;
 import com.ericsson.gerrit.plugins.eiffel.events.EiffelSourceChangeSubmittedEvent;
 import com.ericsson.gerrit.plugins.eiffel.events.EventType;
 import com.ericsson.gerrit.plugins.eiffel.events.models.Link;
@@ -37,13 +37,13 @@ public final class EiffelSourceChangeSubmittedEventGenerator extends EiffelEvent
      * Extracts information from the ChangeMergedEvent and generates an
      * EiffelSourceChangeSubmittedEvent
      *
-     * @param changeMergedEvent
+     * @param pluginConfig
      * @param commitInformation
      * @param pluginConfig
      * @return EiffelSourceChangeSubmittedEvent
      */
-    public static EiffelSourceChangeSubmittedEvent generate(ChangeMergedEvent changeMergedEvent,
-            File pluginDirectoryPath, CommitInformation commitInformation) {
+    public static EiffelSourceChangeSubmittedEvent generate(final EiffelPluginConfiguration pluginConfig,
+            final ChangeMergedEvent changeMergedEvent, final CommitInformation commitInformation) {
         final ChangeAttribute changeAttribute = changeMergedEvent.change.get();
         final PatchSetAttribute patchSetAttribute = changeMergedEvent.patchSet.get();
         final String commitId = changeMergedEvent.newRev;
@@ -55,7 +55,7 @@ public final class EiffelSourceChangeSubmittedEventGenerator extends EiffelEvent
         final String email = patchSetAttribute.author.email;
         final String changeId = changeMergedEvent.changeKey.toString();
 
-        EiffelSourceChangeSubmittedEvent eiffelEvent = new EiffelSourceChangeSubmittedEvent();
+        final EiffelSourceChangeSubmittedEvent eiffelEvent = new EiffelSourceChangeSubmittedEvent();
         eiffelEvent.msgParams.meta.type = TYPE;
         eiffelEvent.msgParams.meta.source.name = META_SOURCE_NAME;
         eiffelEvent.msgParams.meta.source.host = determineHostName();
@@ -70,16 +70,17 @@ public final class EiffelSourceChangeSubmittedEventGenerator extends EiffelEvent
         eiffelEvent.eventParams.data.gitIdentifier.branch = branch;
         eiffelEvent.eventParams.data.gitIdentifier.repoName = projectName;
 
-        String previousSourceChangeCreatedEvent = getPreviousEiffelEventId(EventType.SCC_EVENT,
-                projectName, changeId, pluginDirectoryPath);
+        final String previousSourceChangeCreatedEvent = getPreviousEiffelEventId(pluginConfig,
+                EventType.SCC_EVENT, changeId);
         final Link changeLink = createLink(LINK_TYPE_CHANGE, previousSourceChangeCreatedEvent);
         if (changeLink != null) {
             eiffelEvent.eventParams.links.add(changeLink);
         }
 
-        List<String> parentsSHAs = commitInformation.getParentsSHAs(commitId, projectName);
-        String previousSourceChangeSubmittedEventId = getPreviousEiffelEventId(EventType.SCS_EVENT,
-                projectName, parentsSHAs, pluginDirectoryPath);
+        final List<String> parentsSHAs = commitInformation.getParentsSHAs(commitId, projectName);
+        final String previousSourceChangeSubmittedEventId = getPreviousEiffelEventId(pluginConfig,
+                EventType.SCS_EVENT,
+                parentsSHAs);
         final Link previousVersionLink = createLink(LINK_TYPE_PREVIOUS_VERSION,
                 previousSourceChangeSubmittedEventId);
         if (previousVersionLink != null) {

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/listeners/ChangeMergedEventListener.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/listeners/ChangeMergedEventListener.java
@@ -54,19 +54,19 @@ public class ChangeMergedEventListener extends AbstractEventListener {
     }
 
     @Override
-    protected boolean isExpectedGerritEvent(Event gerritEvent) {
+    protected boolean isExpectedGerritEvent(final Event gerritEvent) {
         return gerritEvent instanceof ChangeMergedEvent;
     }
 
     @Override
-    protected void prepareAndSendEiffelEvent(Event gerritEvent,
-            EiffelPluginConfiguration pluginConfig) {
-        ChangeMergedEvent changeMergedEvent = (ChangeMergedEvent) gerritEvent;
+    protected void prepareAndSendEiffelEvent(final Event gerritEvent,
+            final EiffelPluginConfiguration pluginConfig) {
+        final ChangeMergedEvent changeMergedEvent = (ChangeMergedEvent) gerritEvent;
         LOGGER.info("ChangeMergedEvent recieved from Gerrit, "
                 + "preparing to send a SourceChangeSubmitted eiffel event.\n{}",
                 changeMergedEvent);
-        EiffelSourceChangeSubmittedEvent eiffelEvent = EiffelSourceChangeSubmittedEventGenerator.generate(
-                changeMergedEvent, pluginDirectoryPath, commitInformation);
+        final EiffelSourceChangeSubmittedEvent eiffelEvent = EiffelSourceChangeSubmittedEventGenerator.generate(
+                pluginConfig, changeMergedEvent, commitInformation);
         sendEiffelEvent(eiffelEvent, pluginConfig);
     }
 }

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/listeners/PatchsetCreatedEventListener.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/listeners/PatchsetCreatedEventListener.java
@@ -55,20 +55,20 @@ public class PatchsetCreatedEventListener extends AbstractEventListener {
     }
 
     @Override
-    protected boolean isExpectedGerritEvent(Event gerritEvent) {
+    protected boolean isExpectedGerritEvent(final Event gerritEvent) {
         return gerritEvent instanceof PatchSetCreatedEvent;
     }
 
     @Override
-    protected void prepareAndSendEiffelEvent(Event gerritEvent,
-            EiffelPluginConfiguration pluginConfig) {
-        PatchSetCreatedEvent patchSetCreatedEvent = (PatchSetCreatedEvent) gerritEvent;
+    protected void prepareAndSendEiffelEvent(final Event gerritEvent,
+            final EiffelPluginConfiguration pluginConfig) {
+        final PatchSetCreatedEvent patchSetCreatedEvent = (PatchSetCreatedEvent) gerritEvent;
         LOGGER.info("PatchSetCreatedEvent recieved from Gerrit, "
                 + "preparing to send a SourceChangeCreated eiffel event.\n{}",
                 patchSetCreatedEvent);
 
-        EiffelSourceChangeCreatedEvent eiffelEvent = EiffelSourceChangeCreatedEventGenerator.generate(
-                patchSetCreatedEvent, pluginDirectoryPath, commitInformation);
+        final EiffelSourceChangeCreatedEvent eiffelEvent = EiffelSourceChangeCreatedEventGenerator.generate(
+                pluginConfig, patchSetCreatedEvent, commitInformation);
         sendEiffelEvent(eiffelEvent, pluginConfig);
     }
 }

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/messaging/EiffelEventSender.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/messaging/EiffelEventSender.java
@@ -16,7 +16,6 @@
 */
 package com.ericsson.gerrit.plugins.eiffel.messaging;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.ConnectException;
@@ -56,19 +55,16 @@ public class EiffelEventSender {
     private final Gson gson = new Gson();
     private EiffelEvent eiffelEvent;
     private String eiffelType;
-    private EiffelPluginConfiguration pluginConfig;
-    private HttpRequest httpRequest;
-    private File pluginDir;
+    private final EiffelPluginConfiguration pluginConfig;
+    private final HttpRequest httpRequest;
 
-    public EiffelEventSender(File pluginDir, EiffelPluginConfiguration pluginConfig) {
-        this(pluginDir, pluginConfig, new HttpRequest(HttpMethod.POST));
+    public EiffelEventSender(final EiffelPluginConfiguration pluginConfig) {
+        this(pluginConfig, new HttpRequest(HttpMethod.POST));
     }
 
-    public EiffelEventSender(File pluginDir, EiffelPluginConfiguration pluginConfig,
-            HttpRequest httpRequest) {
+    public EiffelEventSender(final EiffelPluginConfiguration pluginConfig, final HttpRequest httpRequest) {
         this.httpRequest = httpRequest;
         this.pluginConfig = pluginConfig;
-        this.pluginDir = pluginDir;
     }
 
     /**
@@ -79,18 +75,19 @@ public class EiffelEventSender {
     public void send() {
         try {
             verifyConfiguration();
-            String generatedEventId = generateAndPublish();
-            EventStorage eventStorage = EventStorageFactory.getEventStorage(pluginDir, eiffelEvent.msgParams.meta.type);
+            final String generatedEventId = generateAndPublish();
+            final EventStorage eventStorage = EventStorageFactory.getEventStorage(pluginConfig,
+                    eiffelEvent.msgParams.meta.type);
             eventStorage.saveEventId(generatedEventId, eiffelEvent);
 
         } catch (URISyntaxException | MissingConfigurationException | NoSuchElementException e) {
             LOGGER.error("Failed to send eiffel message.", e);
         } catch (SQLException | ConnectException e) {
             LOGGER.error("Failed to save the internal state after sending event.", e);
-        } catch (HttpRequestFailedException e) {
+        } catch (final HttpRequestFailedException e) {
             LOGGER.error("Failed to send eiffel message.", e);
             throw e;
-        } catch (IOException e) {
+        } catch (final IOException e) {
             LOGGER.error("Failed to send eiffel message.", e);
             throw new HttpRequestFailedException(e);
         }
@@ -113,7 +110,7 @@ public class EiffelEventSender {
         final ResponseEntity response = httpRequest.performRequest();
         verifyResponse(response);
 
-        String generatedEventId = getGeneratedEventId(response);
+        final String generatedEventId = getGeneratedEventId(response);
         return generatedEventId;
     }
 
@@ -125,7 +122,7 @@ public class EiffelEventSender {
         return generatedEventId;
     }
 
-    private void verifyResponse(ResponseEntity response) throws HttpRequestFailedException {
+    private void verifyResponse(final ResponseEntity response) throws HttpRequestFailedException {
         final int statusCode = response.getStatusCode();
         final String result = response.getBody();
 
@@ -151,7 +148,7 @@ public class EiffelEventSender {
     }
 
     private boolean isConfigurationSet() {
-        boolean isConfigurationSet = eiffelEvent != null
+        final boolean isConfigurationSet = eiffelEvent != null
                 && !StringUtils.isEmpty(eiffelType);
         return isConfigurationSet;
     }

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/storage/EventStorageFactory.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/storage/EventStorageFactory.java
@@ -17,22 +17,21 @@
 
 package com.ericsson.gerrit.plugins.eiffel.storage;
 
-import java.io.File;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.ericsson.gerrit.plugins.eiffel.configuration.EiffelPluginConfiguration;
 import com.ericsson.gerrit.plugins.eiffel.events.EventType;
 
 public class EventStorageFactory {
     protected static final Logger LOGGER = LoggerFactory.getLogger(EventStorageFactory.class);
 
-    public static EventStorage getEventStorage(File pluginDir, String eventType) {
+    public static EventStorage getEventStorage(final EiffelPluginConfiguration pluginConfig, final String eventType) {
         switch (eventType) {
             case EventType.SCC_EVENT:
-                return new SourceChangeCreatedStorage(pluginDir);
+                return new SourceChangeCreatedStorage(pluginConfig);
             case EventType.SCS_EVENT:
-                return new SourceChangeSubmittedStorage(pluginDir);
+                return new SourceChangeSubmittedStorage(pluginConfig);
             default:
                 throw new IllegalArgumentException("The event type does not exist " + eventType + ".");
         }

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/storage/SourceChangeCreatedStorage.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/storage/SourceChangeCreatedStorage.java
@@ -17,11 +17,11 @@
 
 package com.ericsson.gerrit.plugins.eiffel.storage;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.ConnectException;
 import java.sql.SQLException;
 
+import com.ericsson.gerrit.plugins.eiffel.configuration.EiffelPluginConfiguration;
 import com.ericsson.gerrit.plugins.eiffel.events.EiffelEvent;
 import com.ericsson.gerrit.plugins.eiffel.events.EiffelSourceChangeCreatedEvent;
 import com.ericsson.gerrit.plugins.eiffel.exceptions.NoSuchElementException;
@@ -29,22 +29,21 @@ import com.ericsson.gerrit.plugins.eiffel.handlers.Table;
 
 public class SourceChangeCreatedStorage extends EventStorage {
 
-    public SourceChangeCreatedStorage(File pluginDir) {
-        super(pluginDir);
+    public SourceChangeCreatedStorage(final EiffelPluginConfiguration pluginConfig) {
+        super(pluginConfig);
     }
 
     @Override
-    public String getEventId(String project, String changeId) throws NoSuchElementException, ConnectException, FileNotFoundException {
+    public String getEventId(final String project, final String changeId) throws NoSuchElementException, ConnectException, FileNotFoundException {
         return getLastSavedEiffelEvent(project, changeId, Table.SCC_TABLE);
     }
 
     @Override
-    public void saveEventId(String eiffelEventId, EiffelEvent eiffelEvent)
+    public void saveEventId(final String eiffelEventId, final EiffelEvent eiffelEvent)
             throws NoSuchElementException, SQLException, ConnectException {
-        EiffelSourceChangeCreatedEvent eiffelSourceChangeCreatedEvent = (EiffelSourceChangeCreatedEvent) eiffelEvent;
-        String projectName = eiffelSourceChangeCreatedEvent.eventParams.data.gitIdentifier.repoName;
-        String searchCriteria = eiffelSourceChangeCreatedEvent.eventParams.data.change.id;
+        final EiffelSourceChangeCreatedEvent eiffelSourceChangeCreatedEvent = (EiffelSourceChangeCreatedEvent) eiffelEvent;
+        final String searchCriteria = eiffelSourceChangeCreatedEvent.eventParams.data.change.id;
 
-        saveEiffelEventId(projectName, searchCriteria, eiffelEventId, Table.SCC_TABLE);
+        saveEiffelEventId(searchCriteria, eiffelEventId, Table.SCC_TABLE);
     }
 }

--- a/src/main/java/com/ericsson/gerrit/plugins/eiffel/storage/SourceChangeSubmittedStorage.java
+++ b/src/main/java/com/ericsson/gerrit/plugins/eiffel/storage/SourceChangeSubmittedStorage.java
@@ -17,11 +17,11 @@
 
 package com.ericsson.gerrit.plugins.eiffel.storage;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.ConnectException;
 import java.sql.SQLException;
 
+import com.ericsson.gerrit.plugins.eiffel.configuration.EiffelPluginConfiguration;
 import com.ericsson.gerrit.plugins.eiffel.events.EiffelEvent;
 import com.ericsson.gerrit.plugins.eiffel.events.EiffelSourceChangeSubmittedEvent;
 import com.ericsson.gerrit.plugins.eiffel.exceptions.NoSuchElementException;
@@ -29,22 +29,21 @@ import com.ericsson.gerrit.plugins.eiffel.handlers.Table;
 
 public class SourceChangeSubmittedStorage extends EventStorage {
 
-    public SourceChangeSubmittedStorage(File pluginDir) {
-        super(pluginDir);
+    public SourceChangeSubmittedStorage(final EiffelPluginConfiguration pluginConfig) {
+        super(pluginConfig);
     }
 
     @Override
-    public String getEventId(String project, String branch) throws NoSuchElementException, ConnectException, FileNotFoundException {
+    public String getEventId(final String project, final String branch) throws NoSuchElementException, ConnectException, FileNotFoundException {
         return getLastSavedEiffelEvent(project, branch, Table.SCS_TABLE);
     }
 
     @Override
-    public void saveEventId(String eiffelEventId, EiffelEvent eiffelEvent)
+    public void saveEventId(final String eiffelEventId, final EiffelEvent eiffelEvent)
             throws NoSuchElementException, ConnectException, SQLException {
-        EiffelSourceChangeSubmittedEvent eiffelSourceChangeSubmittedEvent = (EiffelSourceChangeSubmittedEvent) eiffelEvent;
-        String projectName = eiffelSourceChangeSubmittedEvent.eventParams.data.gitIdentifier.repoName;
-        String searchCriteria = eiffelSourceChangeSubmittedEvent.eventParams.data.gitIdentifier.commitId;
+        final EiffelSourceChangeSubmittedEvent eiffelSourceChangeSubmittedEvent = (EiffelSourceChangeSubmittedEvent) eiffelEvent;
+        final String searchCriteria = eiffelSourceChangeSubmittedEvent.eventParams.data.gitIdentifier.commitId;
 
-        saveEiffelEventId(projectName, searchCriteria, eiffelEventId, Table.SCS_TABLE);
+        saveEiffelEventId(searchCriteria, eiffelEventId, Table.SCS_TABLE);
     }
 }

--- a/src/test/java/com/ericsson/gerrit/plugins/eiffel/configuration/EiffelPluginConfigurationTest.java
+++ b/src/test/java/com/ericsson/gerrit/plugins/eiffel/configuration/EiffelPluginConfigurationTest.java
@@ -1,6 +1,5 @@
 package com.ericsson.gerrit.plugins.eiffel.configuration;
 
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -15,6 +14,8 @@ import com.google.gerrit.server.config.PluginConfigFactory;
 import com.google.gerrit.server.project.NoSuchProjectException;
 
 public class EiffelPluginConfigurationTest {
+
+    private static final String PROJECT_NAME = "project";
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
@@ -34,22 +35,29 @@ public class EiffelPluginConfigurationTest {
 
     @Before
     public void init() throws NoSuchProjectException {
-        nameKey = mock(NameKey.class);
+        nameKey = new NameKey(PROJECT_NAME);
         pluginConfigFactory = mock(PluginConfigFactory.class);
         pluginConfig = mock(PluginConfig.class);
 
-        when(pluginConfigFactory.getFromProjectConfig(nameKey, PLUGIN_NAME)).thenReturn(pluginConfig);
-        when(pluginConfig.getBoolean(EiffelPluginConfiguration.ENABLED, false)).thenReturn(ENABLED_TRUE);
+        when(pluginConfigFactory.getFromProjectConfig(nameKey, PLUGIN_NAME)).thenReturn(
+                pluginConfig);
+        when(pluginConfig.getBoolean(EiffelPluginConfiguration.ENABLED, false)).thenReturn(
+                ENABLED_TRUE);
         when(pluginConfig.getStringList(EiffelPluginConfiguration.FILTER)).thenReturn(FILTER);
-        when(pluginConfig.getStringList(EiffelPluginConfiguration.FLOW_CONTEXT)).thenReturn(FLOW_CONTEXT);
-        when(pluginConfig.getString(EiffelPluginConfiguration.REMREM_PUBLISH_URL)).thenReturn(REMREM_PUBLISH_URL);
-        when(pluginConfig.getString(EiffelPluginConfiguration.REMREM_USERNAME)).thenReturn(REMREM_USERNAME);
-        when(pluginConfig.getString(EiffelPluginConfiguration.REMREM_PASSWORD)).thenReturn(REMREM_PASSWORD);
+        when(pluginConfig.getStringList(EiffelPluginConfiguration.FLOW_CONTEXT)).thenReturn(
+                FLOW_CONTEXT);
+        when(pluginConfig.getString(EiffelPluginConfiguration.REMREM_PUBLISH_URL)).thenReturn(
+                REMREM_PUBLISH_URL);
+        when(pluginConfig.getString(EiffelPluginConfiguration.REMREM_USERNAME)).thenReturn(
+                REMREM_USERNAME);
+        when(pluginConfig.getString(EiffelPluginConfiguration.REMREM_PASSWORD)).thenReturn(
+                REMREM_PASSWORD);
     }
 
     @Test
     public void testEiffelPluginConfigurationException1() throws NoSuchProjectException {
-        when(pluginConfigFactory.getFromProjectConfig(nameKey, PLUGIN_NAME)).thenThrow(NoSuchProjectException.class);
+        when(pluginConfigFactory.getFromProjectConfig(nameKey, PLUGIN_NAME)).thenThrow(
+                NoSuchProjectException.class);
         exception.expect(ExceptionInInitializerError.class);
 
         new EiffelPluginConfiguration(PLUGIN_NAME, nameKey, pluginConfigFactory);
@@ -65,46 +73,61 @@ public class EiffelPluginConfigurationTest {
 
     @Test
     public void testEiffelPluginConfigurationDisabled() throws NoSuchProjectException {
-        when(pluginConfig.getBoolean(EiffelPluginConfiguration.ENABLED, false)).thenReturn(ENABLED_FALSE);
+        when(pluginConfig.getBoolean(EiffelPluginConfiguration.ENABLED, false)).thenReturn(
+                ENABLED_FALSE);
 
-        EiffelPluginConfiguration pluginConfig = new EiffelPluginConfiguration(PLUGIN_NAME, nameKey,
+        final EiffelPluginConfiguration pluginConfig = new EiffelPluginConfiguration(PLUGIN_NAME,
+                nameKey,
                 pluginConfigFactory);
-        assertEquals(pluginConfig.isEnabled(), false);
+        assertEquals(false, pluginConfig.isEnabled());
     }
 
     @Test
     public void testEiffelPluginConfigurationRemremGenerateURL() throws NoSuchProjectException {
-        EiffelPluginConfiguration pluginConfig = new EiffelPluginConfiguration(PLUGIN_NAME, nameKey,
+        final EiffelPluginConfiguration pluginConfig = new EiffelPluginConfiguration(PLUGIN_NAME,
+                nameKey,
                 pluginConfigFactory);
-        assertEquals(pluginConfig.getRemremPublishURL(), REMREM_PUBLISH_URL);
+        assertEquals(REMREM_PUBLISH_URL, pluginConfig.getRemremPublishURL());
     }
 
     @Test
     public void testEiffelPluginConfigurationRemremUsername() throws NoSuchProjectException {
-        EiffelPluginConfiguration pluginConfig = new EiffelPluginConfiguration(PLUGIN_NAME, nameKey,
+        final EiffelPluginConfiguration pluginConfig = new EiffelPluginConfiguration(PLUGIN_NAME,
+                nameKey,
                 pluginConfigFactory);
-        assertEquals(pluginConfig.getRemremUsername(), REMREM_USERNAME);
+        assertEquals(REMREM_USERNAME, pluginConfig.getRemremUsername());
     }
 
     @Test
     public void testEiffelPluginConfigurationFilter() throws NoSuchProjectException {
-        EiffelPluginConfiguration pluginConfig = new EiffelPluginConfiguration(PLUGIN_NAME, nameKey,
+        final EiffelPluginConfiguration pluginConfig = new EiffelPluginConfiguration(PLUGIN_NAME,
+                nameKey,
                 pluginConfigFactory);
-        assertEquals(pluginConfig.getFilter(), "");
+        assertEquals("", pluginConfig.getFilter());
     }
 
     @Test
     public void testEiffelPluginConfigurationtFlowContext() throws NoSuchProjectException {
-        EiffelPluginConfiguration pluginConfig = new EiffelPluginConfiguration(PLUGIN_NAME, nameKey,
+        final EiffelPluginConfiguration pluginConfig = new EiffelPluginConfiguration(PLUGIN_NAME,
+                nameKey,
                 pluginConfigFactory);
-        assertEquals(pluginConfig.getFlowContext(), "");
+        assertEquals("", pluginConfig.getFlowContext());
     }
 
     @Test
     public void testEiffelPluginConfigurationEnabled() throws NoSuchProjectException {
-        EiffelPluginConfiguration pluginConfig = new EiffelPluginConfiguration(PLUGIN_NAME, nameKey,
+        final EiffelPluginConfiguration pluginConfig = new EiffelPluginConfiguration(PLUGIN_NAME,
+                nameKey,
                 pluginConfigFactory);
-        assertEquals(pluginConfig.isEnabled(), ENABLED_TRUE);
+        assertEquals(ENABLED_TRUE, pluginConfig.isEnabled());
+    }
+
+    @Test
+    public void testEiffelPluginConfigurationGetProject() throws NoSuchProjectException {
+        final EiffelPluginConfiguration pluginConfig = new EiffelPluginConfiguration(PLUGIN_NAME,
+                nameKey,
+                pluginConfigFactory);
+        assertEquals(PROJECT_NAME, pluginConfig.getProject());
     }
 
 }

--- a/src/test/java/com/ericsson/gerrit/plugins/eiffel/listeners/TestAbstractEventListener.java
+++ b/src/test/java/com/ericsson/gerrit/plugins/eiffel/listeners/TestAbstractEventListener.java
@@ -211,15 +211,15 @@ class ListenerTestMock extends AbstractEventListener {
     private boolean isExpectedGerritEvent = false;
     private EiffelPluginConfiguration pluginConfig;
 
-    public ListenerTestMock(String pluginName, File pluginDir) {
+    public ListenerTestMock(final String pluginName, final File pluginDir) {
         super(pluginName, pluginDir);
     }
 
-    public void setPluginConfig(EiffelPluginConfiguration pluginConfig) {
+    public void setPluginConfig(final EiffelPluginConfiguration pluginConfig) {
         this.pluginConfig = pluginConfig;
     }
 
-    public void setIsExpectedGerritEvent(boolean isExpectedGerritEvent) {
+    public void setIsExpectedGerritEvent(final boolean isExpectedGerritEvent) {
         this.isExpectedGerritEvent = isExpectedGerritEvent;
     }
 
@@ -251,7 +251,7 @@ class ListenerTestMock extends AbstractEventListener {
      * @param pluginConfig
      * @return
      */
-    public boolean verifyPluginEnabled(Event gerritEvent, EiffelPluginConfiguration pluginConfig) {
+    public boolean verifyPluginEnabled(final Event gerritEvent, final EiffelPluginConfiguration pluginConfig) {
         return isEiffelEventSendingEnabled(gerritEvent, pluginConfig);
     }
 
@@ -259,7 +259,7 @@ class ListenerTestMock extends AbstractEventListener {
      * This method is enforced by the AbstractEventListener and not used in test.
      */
     @Override
-    protected boolean isExpectedGerritEvent(Event gerritEvent) {
+    protected boolean isExpectedGerritEvent(final Event gerritEvent) {
         if (isExpectedGerritEvent) {
             isExpectedGerritEvent = false;
             return true;
@@ -271,8 +271,8 @@ class ListenerTestMock extends AbstractEventListener {
      * This method is enforced by the AbstractEventListener and not used in test.
      */
     @Override
-    protected void prepareAndSendEiffelEvent(Event gerritEvent,
-            EiffelPluginConfiguration pluginConfig) {
+    protected void prepareAndSendEiffelEvent(final Event gerritEvent,
+            final EiffelPluginConfiguration pluginConfig) {
         isPrepareAndSendEiffelEventMethodCalled = true;
     }
 

--- a/src/test/java/com/ericsson/gerrit/plugins/eiffel/messaging/EiffelEventSenderTest.java
+++ b/src/test/java/com/ericsson/gerrit/plugins/eiffel/messaging/EiffelEventSenderTest.java
@@ -1,6 +1,5 @@
 package com.ericsson.gerrit.plugins.eiffel.messaging;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
@@ -23,7 +22,6 @@ public class EiffelEventSenderTest {
     private EiffelPluginConfiguration pluginConfig;
     private HttpRequest httpRequest;
     private ResponseEntity response;
-    private File pluginDir;
 
     private static final String EIFFEL_TYPE = "EiffelSourceChangeCreatedEvent";
     private static final int STATUS_OK = HttpStatus.SC_OK;
@@ -38,7 +36,7 @@ public class EiffelEventSenderTest {
     public void testEventSender() throws Exception {
         setUpMockActions();
 
-        EiffelEventSender sender = new EiffelEventSender(pluginDir, pluginConfig, httpRequest);
+        final EiffelEventSender sender = new EiffelEventSender(pluginConfig, httpRequest);
         sender.setEiffelEventMessage(new EiffelSourceChangeCreatedEvent());
         sender.setEiffelEventType(EIFFEL_TYPE);
 
@@ -48,7 +46,7 @@ public class EiffelEventSenderTest {
 
     @Test(expected = MissingConfigurationException.class)
     public void testEventSenderWithMissingConfiguration() throws Exception {
-        EiffelEventSender sender = new EiffelEventSender(pluginDir, pluginConfig, httpRequest);
+        final EiffelEventSender sender = new EiffelEventSender(pluginConfig, httpRequest);
         sender.setEiffelEventMessage(new EiffelSourceChangeCreatedEvent());
         sender.setEiffelEventType("");
 
@@ -59,7 +57,7 @@ public class EiffelEventSenderTest {
     public void testEventSenderWithBadStatus() throws Exception {
         setUpMockActionsWithBadStatus();
 
-        EiffelEventSender sender = new EiffelEventSender(pluginDir, pluginConfig, httpRequest);
+        final EiffelEventSender sender = new EiffelEventSender(pluginConfig, httpRequest);
         sender.setEiffelEventMessage(new EiffelSourceChangeCreatedEvent());
         sender.setEiffelEventType(EIFFEL_TYPE);
 
@@ -70,7 +68,6 @@ public class EiffelEventSenderTest {
         httpRequest = Mockito.mock(HttpRequest.class);
         pluginConfig = Mockito.mock(EiffelPluginConfiguration.class);
         response = Mockito.mock(ResponseEntity.class);
-        pluginDir = Mockito.mock(File.class);
     }
 
     private void setUpMockActions() throws URISyntaxException, IOException {


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests.
-->

### Applicable Issues


### Description of the Change
In many places, the plugin dir and/or the project name was passed around. The change introduced in this pull requests changes this behavior and passes the plugin configuration instead

### Alternate Designs
Leave it, but the code would be harder to read.

### Benefits
Less passing of variables

### Possible Drawbacks


### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Mattias Linnér, mattias.linner@ericsson.com
