### PR TITLE
Add windows support for bash scripts

### DIFF
--- a/eiffel-gerrit-plugin-script
+++ b/eiffel-gerrit-plugin-script
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-GERRIT_API_HOST=""
+API_HOST=""
 STATUS=0
 
 function invalid_arguments {
@@ -33,7 +33,7 @@ function do_stop {
   docker-compose -f target/docker-compose.yml down
   if [ $? -eq 1 ]; then
     echo "Failed to stop docker containers!"
-    exit 1  
+    exit 1
   fi
 }
 
@@ -52,8 +52,8 @@ function do_rebuild {
   docker build -f target/Dockerfile -t plugin-test target/ --build-arg JAR_LOCATION=./$JAR_LOCATION
   if [ $? -eq 1 ]; then
     echo "Failed to build docker file!"
-    exit 1  
-  fi 
+    exit 1
+  fi
 }
 
 function do_start {
@@ -75,12 +75,8 @@ function do_test {
   echo "########### RUNNING TESTS ##############"
   echo "########################################"
 
-  GERRIT_CONTAINER_ID=$(docker ps | grep target_gerrit | awk '{print $1}')
-  GERRIT_API_HOST=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $GERRIT_CONTAINER_ID)
-
-  # Installing firefox binary before integration tests
-  # mvn exec:exec
-  mvn verify -DskipUTs -Dgerrit.url=$GERRIT_API_HOST
+  set_api_host target_gerrit
+  mvn verify -DskipUTs -Dgerrit.url=$API_HOST
   STATUS=$?
 }
 
@@ -100,18 +96,40 @@ function do_full_test {
   do_stop
 }
 
+function set_api_host {
+  container_name="$1"
+
+  unamestr=`uname`
+  if [[ "$unamestr" == "Linux" ]]; then
+    CONTAINER_ID=$(docker ps | grep ${container_name} | awk '{print $1}')
+    API_HOST=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $CONTAINER_ID)
+  elif [[ "$unamestr" == MINGW64_NT* ]]; then
+    API_HOST=localhost
+  else
+    echo "Unsupported operating system, this script currently only works in Linux and Windows!"
+    exit 1
+  fi
+}
+
+function check_supported_systems {
+  unamestr=`uname`
+  if [[ "$unamestr" != "Linux" && "$unamestr" != MINGW64_NT* ]]; then
+    echo "Unsupported operating system, this script currently only works in Linux and Windows!"
+    exit 1
+  fi
+}
+
 function wait_for_service {
   service_name="$1"
   container_name="$2"
   container_port="$3"
-  
+
   attempt_counter=0
   max_attempts=60
-  
-  CONTAINER_ID=$(docker ps | grep ${container_name} | awk '{print $1}')
-  API_HOST=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $CONTAINER_ID)
+
+  set_api_host $container_name
   BASE_URL=http://$API_HOST:${container_port}
-    
+
   printf "WAITING FOR $service_name TO START WITH URL: "$BASE_URL
   echo " "
   until $(curl --output /dev/null --silent --head --fail $BASE_URL); do
@@ -132,15 +150,11 @@ function wait_for_service {
   echo " "
 }
 
-unamestr=`uname`
-if [ "$unamestr" != "Linux" ]; then
-   echo "Unsupported operating system, this script currently only works in Linux!"
-   exit 1
-fi
-
 if [ $# -eq 0 ]; then
   invalid_arguments
 fi
+
+check_supported_systems
 
 if [[ "start stop test only_test restart rebuild build" =~ .*${1}.* ]];
 then
@@ -164,4 +178,3 @@ else
 fi
 
 exit $STATUS
-

--- a/eiffel-gerrit-plugin-script
+++ b/eiffel-gerrit-plugin-script
@@ -99,7 +99,7 @@ function do_full_test {
 function set_api_host {
   container_name="$1"
 
-  unamestr=`uname`
+  unamestr=$(uname)
   if [[ "$unamestr" == "Linux" ]]; then
     CONTAINER_ID=$(docker ps | grep ${container_name} | awk '{print $1}')
     API_HOST=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $CONTAINER_ID)

--- a/src/main/docker/env.bash
+++ b/src/main/docker/env.bash
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
 
-export HOST=$(hostname -I | tr " " "\n"| head -1);
-echo "Docker Host IP: $HOST"
+unamestr=`uname`
+if [[ "$unamestr" == "Linux" ]]; then
+  export HOST=$(hostname -I | tr " " "\n"| head -1);
+elif [[ "$unamestr" == MINGW64_NT* ]]; then
+  export HOST=localhost
+else
+  echo "Unsupported operating system, this script currently only works in Linux and Windows!"
+  exit 1
+fi
+
+echo "Docker Host: $HOST"
 
 export RABBITMQ_IMAGE="bitnami/rabbitmq:3.7.8-debian-9"
 export REMREM_GENERATE_IMAGE="eiffelericsson/eiffel-remrem-generate:2.0.4"

--- a/src/main/docker/env.bash
+++ b/src/main/docker/env.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-unamestr=`uname`
+unamestr=$(uname)
 if [[ "$unamestr" == "Linux" ]]; then
   export HOST=$(hostname -I | tr " " "\n"| head -1);
 elif [[ "$unamestr" == MINGW64_NT* ]]; then


### PR DESCRIPTION

### Description of the Change
Let the bash scripts support windows environments

### Benefits
Windows users can run the eiffel-gerrit-plugin-sciprt without having to modify it for windows

### Possible Drawbacks
Added complexity in scripts

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Mattias Linnér mattias.linner@ericsson.com
